### PR TITLE
Adding a deeper check for chunk decoder

### DIFF
--- a/cs2-voice-data.go
+++ b/cs2-voice-data.go
@@ -3,13 +3,14 @@ package main
 import (
 	"CS2VoiceData/decoder"
 	"fmt"
+	"log"
+	"os"
+	"strconv"
+
 	"github.com/go-audio/audio"
 	"github.com/go-audio/wav"
 	dem "github.com/markus-wa/demoinfocs-golang/v4/pkg/demoinfocs"
 	"github.com/markus-wa/demoinfocs-golang/v4/pkg/demoinfocs/msgs2"
-	"log"
-	"os"
-	"strconv"
 )
 
 func main() {
@@ -65,7 +66,7 @@ func convertAudioDataToWavFiles(payloads [][]byte, fileName string) {
 		}
 
 		// Not silent frame
-		if len(c.Data) > 0 {
+		if c != nil && len(c.Data) > 0 {
 			pcm, err := voiceDecoder.Decode(c.Data)
 
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module CS2VoiceData
 
 go 1.21
 
+toolchain go1.21.4
+
 require (
 	github.com/go-audio/audio v1.0.0
 	github.com/go-audio/wav v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-audio/audio v1.0.0 h1:zS9vebldgbQqktK4H0lUqWrG8P0NxCJVqcj7ZpNnwd4=
 github.com/go-audio/audio v1.0.0/go.mod h1:6uAu0+H2lHkwdGsAY+j2wHPNPpPoeg5AaEFh9FlA+Zs=
 github.com/go-audio/riff v1.0.0 h1:d8iCGbDvox9BfLagY94fBynxSPHO80LmZCaOsmKxokA=
@@ -36,10 +35,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.1 h1:4VhoImhV/Bm0ToFkXFi8hXNXwpDRZ/ynw3amt82mzq0=
-github.com/stretchr/objx v0.5.1/go.mod h1:/iHQpkQwBD6DLUmQ4pE+s1TXdob1mORJ4/UFdrifcy0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
@@ -50,4 +47,3 @@ gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302 h1:xeVptzkP8BuJhoIjNi
 gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302/go.mod h1:/L5E7a21VWl8DeuCPKxQBdVG5cy+L0MRZ08B1wnqt7g=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Expected behavior:
Parse the demo and all the voices and save them

Behavior that occurred:
_invalid voice packet (has 174 bytes remaining, expected 4 bytes remaining)
panic: runtime error: invalid memory address or nil pointer dereference_

Explanation:
There have been multiple cases where, given a demo file, the parser would panic due to a nil point reference on trying to read the chunk decoder's data; I simply opted for a normal check on the chunk decoder's existence

To try this example without my fix, it is possible to download the demo from this FACEIT match I played [here](https://www.faceit.com/en/cs2/room/1-81f117ba-86fd-4031-b3d7-67b03d042f38) and the above error will be visible

The other edits were made by Go during the packages installation via `go get ./...` and by the Go extension for VSCode

Hope everything is clear =)

